### PR TITLE
Add component6-component10 extensions for Array types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Change Log
  - Coroutines
      - `combineApply` method on flows to run applies against the current
        flow for each item in a new flow.
+ - Standard
+     - `component6` through `component10` extensions added for `Array<T>` types.
 
 1.0.1
 -----

--- a/standard/api/standard.api
+++ b/standard/api/standard.api
@@ -1,4 +1,9 @@
 public final class com/inkapplications/standard/CollectionsKt {
+	public static final fun component10 ([Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun component6 ([Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun component7 ([Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun component8 ([Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun component9 ([Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun mapSet (Ljava/util/Set;Lkotlin/jvm/functions/Function1;)Ljava/util/Set;
 }
 

--- a/standard/src/commonMain/kotlin/com/inkapplications/standard/Collections.kt
+++ b/standard/src/commonMain/kotlin/com/inkapplications/standard/Collections.kt
@@ -23,3 +23,43 @@ inline fun <T, reified R> Array<T>.mapArray(mapping: (T) -> R): Array<R> {
  * @return A copy of the Set with the data modified
  */
 inline fun <T, R> Set<T>.mapSet(mapping: (T) -> R): Set<R> = map(mapping).toSet()
+
+/**
+ * Returns 6th *element* from the array.
+ *
+ * If the size of this array is less than 6, throws an [IndexOutOfBoundsException] except in Kotlin/JS
+ * where the behavior is unspecified.
+ */
+inline operator fun <T> Array<out T>.component6(): T = get(5)
+
+/**
+ * Returns 7th *element* from the array.
+ *
+ * If the size of this array is less than 7, throws an [IndexOutOfBoundsException] except in Kotlin/JS
+ * where the behavior is unspecified.
+ */
+inline operator fun <T> Array<out T>.component7(): T = get(6)
+
+/**
+ * Returns 8th *element* from the array.
+ *
+ * If the size of this array is less than 8, throws an [IndexOutOfBoundsException] except in Kotlin/JS
+ * where the behavior is unspecified.
+ */
+inline operator fun <T> Array<out T>.component8(): T = get(7)
+
+/**
+ * Returns 9th *element* from the array.
+ *
+ * If the size of this array is less than 9, throws an [IndexOutOfBoundsException] except in Kotlin/JS
+ * where the behavior is unspecified.
+ */
+inline operator fun <T> Array<out T>.component9(): T = get(8)
+
+/**
+ * Returns 10th *element* from the array.
+ *
+ * If the size of this array is less than 10, throws an [IndexOutOfBoundsException] except in Kotlin/JS
+ * where the behavior is unspecified.
+ */
+inline operator fun <T> Array<out T>.component10(): T = get(9)

--- a/standard/src/commonTest/kotlin/com/inkapplications/standard/CollectionsTest.kt
+++ b/standard/src/commonTest/kotlin/com/inkapplications/standard/CollectionsTest.kt
@@ -20,4 +20,15 @@ class CollectionsTest {
         assertEquals("A", result[0])
         assertEquals("B", result[1])
     }
+
+    @Test
+    fun components() {
+        val test = (1..10).toList().toTypedArray()
+
+        assertEquals(6, test.component6())
+        assertEquals(7, test.component7())
+        assertEquals(8, test.component8())
+        assertEquals(9, test.component9())
+        assertEquals(10, test.component10())
+    }
 }


### PR DESCRIPTION
Expands the array components up to 10 items.
This is particularly desired for use with Flow's `combine` method.