### PR TITLE
Publish github release as draft.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,6 @@ jobs:
               with:
                   tag_name: ${{ github.ref }}
                   release_name: ${{ github.ref_name }}
-                  draft: false
+                  draft: true
                   prerelease: false
                   body: "See CHANGELOG.md for details"


### PR DESCRIPTION
Since the maven publications need to be published manually, this step should be on-hold as a draft until the publication is made.